### PR TITLE
Add a timeout to SSH tests

### DIFF
--- a/test/network_helpers.go
+++ b/test/network_helpers.go
@@ -17,6 +17,7 @@ var (
 	// we don't want to retry for too long, but we should do it at least a few times to make sure the instance is up
 	SSHMaxRetriesExpectError = 3
 	SSHSleepBetweenRetries = 3 * time.Second
+	SSHTimeout = 15 * time.Second
 	SSHEchoText = "Hello World"
 )
 


### PR DESCRIPTION
Tests run a little long because we don't have a timeout on failed connections; this should resolve the issue and cut a couple minutes off a run.

Fixes https://github.com/gruntwork-io/terraform-google-network/issues/12