### PR TITLE
Add network name outputs

### DIFF
--- a/modules/vpc-network/outputs.tf
+++ b/modules/vpc-network/outputs.tf
@@ -29,6 +29,10 @@ output "public_subnetwork_secondary_cidr_block" {
   value = "${google_compute_subnetwork.vpc_subnetwork_public.secondary_ip_range.0.ip_cidr_range}"
 }
 
+output "public_subnetwork_secondary_range_name" {
+  value = "${google_compute_subnetwork.vpc_subnetwork_public.secondary_ip_range.0.range_name}"
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # Private Subnetwork Outputs
 # ---------------------------------------------------------------------------------------------------------------------
@@ -53,6 +57,10 @@ output "private_subnetwork_gateway" {
 
 output "private_subnetwork_secondary_cidr_block" {
   value = "${google_compute_subnetwork.vpc_subnetwork_private.secondary_ip_range.0.ip_cidr_range}"
+}
+
+output "private_subnetwork_secondary_range_name" {
+  value = "${google_compute_subnetwork.vpc_subnetwork_private.secondary_ip_range.0.range_name}"
 }
 
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds outputs for `public` and `private` networks' names and secondary range names. 

We need to pass in the network name to the GKE module and pull the data using that. 
The `terraform` data source for `google_compute_network` only allows the network name. 

EDIT: We need to output the secondary range names, as well, because `google_container_cluster` needs 
* `cluster_secondary_range_name` - (Optional) The name of the secondary range to be used as for the cluster CIDR block.