### PR TITLE
Update Network module root to contemporary OSS style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ We also recommend updating the automated tests *before* updating any code (see [
 Development](https://en.wikipedia.org/wiki/Test-driven_development)). That means you add or update a test case, 
 verify that it's failing with a clear error message, and *then* make the code changes to get that test to pass. This 
 ensures the tests stay up to date and verify all the functionality in this Module, including whatever new 
-functionality you're adding in your contribution. Check out the [tests](https://github.com/gruntwork-io/terraform-aws-influx/tree/master/test) folder for instructions on running the 
-automated tests. 
+functionality you're adding in your contribution. Check out the [tests](https://github.com/gruntwork-io/terraform-google-network/tree/master/test) folder for
+instructions on running the automated tests.
 
 ## Update the code
 

--- a/README.md
+++ b/README.md
@@ -1,34 +1,51 @@
+[![Maintained by Gruntwork.io](https://img.shields.io/badge/maintained%20by-gruntwork.io-%235849a6.svg)](https://gruntwork.io/?ref=repo_google_network)
+
 # Google VPC Network Modules
 
 This repo contains modules for creating [Virtual Private Cloud (VPC) networks](https://cloud.google.com/vpc/docs/vpc) on
 Google Cloud Platform (GCP) following best practices.
 
-#### Main Modules
+## Quickstart
 
-The primary module is:
+If you want to quickly spin up a VPC Network in GCP, you can run the example that is in the root of this repo. Check out
+[network-management example documentation](https://github.com/gruntwork-io/terraform-google-network/blob/master/examples/network-management)
+for instructions.
 
-* [vpc-network](/modules/vpc-network): Launch a secure VPC network on GCP.
+## What's in this repo
 
-Inbound traffic to instances in the network is controlled by "access tiers", a pair of subnetwork and [network `tags`](https://cloud.google.com/vpc/docs/add-remove-network-tags).
-By defining an appropriate subnetwork and tag for an instance, you'll ensure that traffic to and from the instance is
-properly restricted. See [the Access Tier table](/modules/vpc-network#access-tier) for more details.
+This repo has the following folder structure:
 
-#### Supporting Modules
+* [root](https://github.com/gruntwork-io/terraform-google-network/tree/master): The root folder contains an example of how
+  to deploy a service-agnostic "management" VPC network in GCP. See [network-management](https://github.com/gruntwork-io/terraform-google-network/blob/master/examples/network-management)
+  for the documentation.
 
-There are also several supporting modules that add extra functionality on top of `vpc-network`:
+* [modules](https://github.com/gruntwork-io/terraform-google-network/tree/master/modules): This folder contains the
+  main implementation code for this Module, broken down into multiple standalone submodules.
 
-* [network-peering](/modules/network-peering): Configure peering connections between your networks, allowing you to
-limit access between environments and reduce the risk of production workloads being compromised.
+  The primary module is:
 
-* [project-host-configuration](/modules/project-host-configuration): Configure your project to be a "host project" whose
-networks can be shared across multiple projects in the organization as part of a defense-in-depth security strategy, and
-to allow service-level billing across different teams within your organization.
+    * [vpc-network](/modules/vpc-network): Launch a secure VPC network on GCP.
 
-* [network-firewall](/modules/network-firewall): Configures the firewall rules expected by the `vpc-network` module.
+    Inbound traffic to instances in the network is controlled by "access tiers", a pair of subnetwork and [network `tags`](https://cloud.google.com/vpc/docs/add-remove-network-tags).
+    By defining an appropriate subnetwork and tag for an instance, you'll ensure that traffic to and from the instance is
+    properly restricted. See [the Access Tier table](/modules/vpc-network#access-tier) for more details.
 
-<!-- TODO: Document Bastion Host, OpenVPC, Firewall modules -->
+    There are also several supporting modules that add extra functionality on top of `vpc-network`:
 
-Click on each module above to see its documentation. Head over to the [examples folder](/examples) for examples.
+    * [network-peering](/modules/network-peering): Configure peering connections between your networks, allowing you to
+    limit access between environments and reduce the risk of production workloads being compromised.
+
+    * [project-host-configuration](/modules/project-host-configuration): Configure your project to be a "host project" whose
+    networks can be shared across multiple projects in the organization as part of a defense-in-depth security strategy, and
+    to allow service-level billing across different teams within your organization.
+
+    * [network-firewall](/modules/network-firewall): Configures the firewall rules expected by the `vpc-network` module.
+
+* [examples](https://github.com/gruntwork-io/terraform-google-network/tree/master/examples): This folder contains
+  examples of how to use the submodules.
+
+* [test](https://github.com/gruntwork-io/terraform-google-network/tree/master/test): Automated tests for the submodules
+  and examples.
 
 ## What's a VPC?
 
@@ -38,6 +55,18 @@ connections between your resources and services both on Google Cloud and outside
 
 Networks are global, and a single network can be used for all of your GCP resources across all regions. Subnetworks,
 ranges of IP addresses within a single region, can be used to usefully partition your private network IP space.
+
+## What's a Module?
+
+A Module is a canonical, reusable, best-practices definition for how to run a single piece of infrastructure, such
+as a database or server cluster. Each Module is written using a combination of [Terraform](https://www.terraform.io/)
+and scripts (mostly bash) and include automated tests, documentation, and examples. It is maintained both by the open
+source community and companies that provide commercial support.
+
+Instead of figuring out the details of how to run a piece of infrastructure from scratch, you can reuse
+existing code that has been proven in production. And instead of maintaining all that infrastructure code yourself,
+you can leverage the work of the Module community to pick up infrastructure improvements through
+a version number bump.
 
 ## Who maintains this Module?
 

--- a/main.tf
+++ b/main.tf
@@ -1,1 +1,150 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# Create a Management Network for shared services
+# ---------------------------------------------------------------------------------------------------------------------
 
+module "management_network" {
+  # When using these modules in your own templates, you will need to use a Git URL with a ref attribute that pins you
+  # to a specific version of the modules, such as the following example:
+  # source = "git::git@github.com:gruntwork-io/terraform-google-network.git//modules/vpc-network?ref=v0.0.1"
+  source = "./modules/vpc-network"
+
+  name_prefix = "${var.name_prefix}"
+  project     = "${var.project}"
+  region      = "${var.region}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Create instances to tag & test connectivity with
+# ---------------------------------------------------------------------------------------------------------------------
+
+data "google_compute_zones" "available" {
+  project = "${var.project}"
+  region  = "${var.region}"
+}
+
+// This instance acts as an arbitrary internet address for testing purposes
+resource "google_compute_instance" "default_network" {
+  name         = "${var.name_prefix}-default-network"
+  machine_type = "n1-standard-1"
+  zone         = "${data.google_compute_zones.available.names[0]}"
+
+  allow_stopping_for_update = true
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    network = "default"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+}
+
+resource "google_compute_instance" "public_with_ip" {
+  name         = "${var.name_prefix}-public-with-ip"
+  machine_type = "n1-standard-1"
+  zone         = "${data.google_compute_zones.available.names[0]}"
+
+  allow_stopping_for_update = true
+
+  tags = ["${module.management_network.public}"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    subnetwork = "${module.management_network.public_subnetwork}"
+
+    access_config {
+      // Ephemeral IP
+    }
+  }
+}
+
+resource "google_compute_instance" "public_without_ip" {
+  name         = "${var.name_prefix}-public-without-ip"
+  machine_type = "n1-standard-1"
+  zone         = "${data.google_compute_zones.available.names[0]}"
+
+  allow_stopping_for_update = true
+
+  tags = ["${module.management_network.public}"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    subnetwork = "${module.management_network.public_subnetwork}"
+  }
+}
+
+resource "google_compute_instance" "private_public" {
+  name         = "${var.name_prefix}-private-public"
+  machine_type = "n1-standard-1"
+  zone         = "${data.google_compute_zones.available.names[0]}"
+
+  allow_stopping_for_update = true
+
+  tags = ["${module.management_network.private}"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    subnetwork = "${module.management_network.public_subnetwork}"
+  }
+}
+
+resource "google_compute_instance" "private" {
+  name         = "${var.name_prefix}-private"
+  machine_type = "n1-standard-1"
+  zone         = "${data.google_compute_zones.available.names[0]}"
+
+  allow_stopping_for_update = true
+
+  tags = ["${module.management_network.private}"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    subnetwork = "${module.management_network.private_subnetwork}"
+  }
+}
+
+resource "google_compute_instance" "private_persistence" {
+  name         = "${var.name_prefix}-private-persistence"
+  machine_type = "n1-standard-1"
+  zone         = "${data.google_compute_zones.available.names[0]}"
+
+  allow_stopping_for_update = true
+
+  tags = ["${module.management_network.private_persistence}"]
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-9"
+    }
+  }
+
+  network_interface {
+    subnetwork = "${module.management_network.private_subnetwork}"
+  }
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,1 +1,99 @@
+output "network" {
+  description = "A reference (self_link) to the VPC network"
+  value       = "${module.management_network.network}"
+}
 
+# ---------------------------------------------------------------------------------------------------------------------
+# Public Subnetwork Outputs
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "public_subnetwork" {
+  description = "A reference (self_link) to the public subnetwork"
+  value       = "${module.management_network.public_subnetwork}"
+}
+
+output "public_subnetwork_cidr_block" {
+  value = "${module.management_network.public_subnetwork_cidr_block}"
+}
+
+output "public_subnetwork_gateway" {
+  value = "${module.management_network.public_subnetwork_gateway}"
+}
+
+output "public_subnetwork_secondary_cidr_block" {
+  value = "${module.management_network.public_subnetwork_secondary_cidr_block}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Private Subnetwork Outputs
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "private_subnetwork" {
+  description = "A reference (self_link) to the private subnetwork"
+  value       = "${module.management_network.private_subnetwork}"
+}
+
+output "private_subnetwork_cidr_block" {
+  value = "${module.management_network.private_subnetwork_cidr_block}"
+}
+
+output "private_subnetwork_gateway" {
+  value = "${module.management_network.private_subnetwork_gateway}"
+}
+
+output "private_subnetwork_secondary_cidr_block" {
+  value = "${module.management_network.private_subnetwork_secondary_cidr_block}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Access Tier - Network Tags
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "public" {
+  description = "The network tag string used for the public access tier"
+  value       = "${module.management_network.public}"
+}
+
+output "private" {
+  description = "The network tag string used for the private access tier"
+  value       = "${module.management_network.private}"
+}
+
+output "private_persistence" {
+  description = "The network tag string used for the private-persistence access tier"
+  value       = "${module.management_network.private_persistence}"
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Instance Info (primarily for testing)
+# ---------------------------------------------------------------------------------------------------------------------
+
+output "instance_default_network" {
+  description = "A reference (self link) to an instance in the default network. Note that the default network allows SSH."
+  value       = "${google_compute_instance.default_network.self_link}"
+}
+
+output "instance_public_with_ip" {
+  description = "A reference (self link) to the instance tagged as public in a public subnetwork with an external IP"
+  value       = "${google_compute_instance.public_with_ip.self_link}"
+}
+
+output "instance_public_without_ip" {
+  description = "A reference (self link) to the instance tagged as public in a public subnetwork without an internet IP"
+  value       = "${google_compute_instance.public_without_ip.self_link}"
+}
+
+output "instance_private_public" {
+  description = "A reference (self link) to the instance tagged as private in a public subnetwork"
+  value       = "${google_compute_instance.private_public.self_link}"
+}
+
+output "instance_private" {
+  description = "A reference (self link) to the instance tagged as private in a private subnetwork"
+  value       = "${google_compute_instance.private.self_link}"
+}
+
+output "instance_private_persistence" {
+  description = "A reference (self link) to the instance tagged as private-persistence in a private subnetwork"
+  value       = "${google_compute_instance.private_persistence.self_link}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,1 +1,22 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# These parameters must be supplied when consuming this module.
+# ---------------------------------------------------------------------------------------------------------------------
 
+variable "project" {
+  description = "The name of the GCP Project where all resources will be launched."
+}
+
+variable "region" {
+  description = "The Region in which all GCP resources will be launched."
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "name_prefix" {
+  description = "A name prefix used in resource names to ensure uniqueness across a project."
+  default     = "management"
+}


### PR DESCRIPTION
Using https://github.com/gruntwork-io/terraform-aws-influx as a template, update the module's root README + add an example at the root.

I diverged a bit in the "What's in this repo" bit- I think listing the primary modules users should interact with is valuable, instead of requiring them to click in to each directory in `modules/`