### PR TITLE
Use a shorter firewall resource name

### DIFF
--- a/modules/network-firewall/main.tf
+++ b/modules/network-firewall/main.tf
@@ -39,7 +39,7 @@ resource "google_compute_firewall" "public_allow_all_inbound" {
 # ---------------------------------------------------------------------------------------------------------------------
 
 resource "google_compute_firewall" "private_allow_all_network_inbound" {
-  name = "${var.name_prefix}-private-allow-network-inbound"
+  name = "${var.name_prefix}-private-allow-ingress"
 
   project = "${var.project}"
   network = "${var.network}"


### PR DESCRIPTION
Sometimes when using the `random` provider in the GKE examples to generate a cluster name, we end up with a network name that is too long for the GCP limits. e.g: `example-private-cluster-network-piqp-private-allow-network-inbound`. If we were to shorten this resource name to `example-private-cluster-network-piqp-private-allow-ingress`, it would work perfectly.

The GCP regex is: `^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$`. You can test here: https://regex-golang.appspot.com/assets/html/index.html.