### PR TITLE
Fix project variable for all compute instances in the example

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ resource "google_compute_instance" "default_network" {
   name         = "${var.name_prefix}-default-network"
   machine_type = "n1-standard-1"
   zone         = data.google_compute_zones.available.names[0]
+  project      = var.project
 
   allow_stopping_for_update = true
 
@@ -55,6 +56,7 @@ resource "google_compute_instance" "public_with_ip" {
   name         = "${var.name_prefix}-public-with-ip"
   machine_type = "n1-standard-1"
   zone         = data.google_compute_zones.available.names[0]
+  project      = var.project
 
   allow_stopping_for_update = true
 
@@ -79,6 +81,7 @@ resource "google_compute_instance" "public_without_ip" {
   name         = "${var.name_prefix}-public-without-ip"
   machine_type = "n1-standard-1"
   zone         = data.google_compute_zones.available.names[0]
+  project      = var.project
 
   allow_stopping_for_update = true
 
@@ -99,6 +102,7 @@ resource "google_compute_instance" "private_public" {
   name         = "${var.name_prefix}-private-public"
   machine_type = "n1-standard-1"
   zone         = data.google_compute_zones.available.names[0]
+  project      = var.project
 
   allow_stopping_for_update = true
 
@@ -119,6 +123,7 @@ resource "google_compute_instance" "private" {
   name         = "${var.name_prefix}-private"
   machine_type = "n1-standard-1"
   zone         = data.google_compute_zones.available.names[0]
+  project      = var.project
 
   allow_stopping_for_update = true
 
@@ -139,6 +144,7 @@ resource "google_compute_instance" "private_persistence" {
   name         = "${var.name_prefix}-private-persistence"
   machine_type = "n1-standard-1"
   zone         = data.google_compute_zones.available.names[0]
+  project      = var.project
 
   allow_stopping_for_update = true
 


### PR DESCRIPTION
Hi Gruntwork, 

Thank you for this great module. I really enjoy using and reading the code and the documentation you write. Such good quality.

I wanted to try this module and got an error.
Here are the commands used: 

```bash 
$ alias tf=terraform
$ tf version
Terraform v0.12.1
+ provider.google v2.5.1
$ tf init
$ tf plan -var=project=XXX -var=region=europe-west1
$ tf apply -var=project=XXX -var=region=europe-west1 -auto-approve
```

Here is the error:

```
Error: project: required field is not set

  on main.tf line 32, in resource "google_compute_instance" "default_network":
  32: resource "google_compute_instance" "default_network" {



Error: project: required field is not set

  on main.tf line 54, in resource "google_compute_instance" "public_with_ip":
  54: resource "google_compute_instance" "public_with_ip" {



Error: project: required field is not set

  on main.tf line 78, in resource "google_compute_instance" "public_without_ip":
  78: resource "google_compute_instance" "public_without_ip" {



Error: project: required field is not set

  on main.tf line 98, in resource "google_compute_instance" "private_public":
  98: resource "google_compute_instance" "private_public" {



Error: project: required field is not set

  on main.tf line 118, in resource "google_compute_instance" "private":
 118: resource "google_compute_instance" "private" {



Error: project: required field is not set

  on main.tf line 138, in resource "google_compute_instance" "private_persistence":
 138: resource "google_compute_instance" "private_persistence" {

```

This PR fix the example.
