### PR TITLE
[skip ci] Use absolute link for image

### DIFF
--- a/examples/network-management/README.md
+++ b/examples/network-management/README.md
@@ -8,7 +8,7 @@ application networks with network peering to access environments like `productio
 See the diagram below for a visual guide to the instances defined in this example. You can see an example of which
 connections between them are valid by browsing the test cases under [this example's tests](../../test/network_test.go)
 
-![Network Diagram](../../.img/management-network-diagram.png)
+![Network Diagram](https://raw.githubusercontent.com/gruntwork-io/terraform-google-network/master/.img/management-network-diagram.png)
 
 ## Limitations
 


### PR DESCRIPTION
Fixes the image in the registry