### PR TITLE
Add private IP in output of bastion_host

### DIFF
--- a/modules/bastion-host/outputs.tf
+++ b/modules/bastion-host/outputs.tf
@@ -8,3 +8,7 @@ output "address" {
   value       = google_compute_instance.bastion_host.network_interface[0].access_config[0].nat_ip
 }
 
+output "internal_address" {
+  description = "The private IP of the bastion host."
+  value       = google_compute_instance.bastion.network_interface[0].network_ip
+}

--- a/modules/bastion-host/outputs.tf
+++ b/modules/bastion-host/outputs.tf
@@ -8,7 +8,7 @@ output "address" {
   value       = google_compute_instance.bastion_host.network_interface[0].access_config[0].nat_ip
 }
 
-output "internal_address" {
+output "private_ip" {
   description = "The private IP of the bastion host."
   value       = google_compute_instance.bastion.network_interface[0].network_ip
 }


### PR DESCRIPTION
When using GKE, I found myself having to do:

```hcl
module "bastion" {
  source = "github.com/gruntwork-io/terraform-google-network//modules/bastion-host"
  # other parameters
}

data "google_compute_instance" "bastion" {
  self_link = module.bastion.instance
}

module "k8s" {
  source = "github.com/gruntwork-io/terraform-google-gke//modules/gke-cluster"

  # other parameters
  master_authorized_networks_config = [{
    cidr_blocks = [{
      cidr_block = "${data.google_compute_instance.bastion.network_interface[0].network_ip}/32"
      display_name = "${var.name_prefix}-bastion-vm"
    }],
  }]
```

I think it would be easier if the module directly expose the private ip of the bastion host.

What do you think? 
Feel free to close this PR if not relevant. 
I'm just happy to contribute 😄 