### PR TITLE
Add bastion startup script

### DIFF
--- a/modules/bastion-host/main.tf
+++ b/modules/bastion-host/main.tf
@@ -28,6 +28,8 @@ resource "google_compute_instance" "bastion_host" {
     }
   }
 
+  metadata_startup_script = var.startup_script
+
   metadata = {
     enable-oslogin = "TRUE"
   }

--- a/modules/bastion-host/variables.tf
+++ b/modules/bastion-host/variables.tf
@@ -48,7 +48,7 @@ variable "source_image" {
 
 variable "startup_script" {
   description = "The script to be executed when the bastion host starts. It can be used to install additional software and/or configure the host."
-  type        = "string"
+  type        = string
   default     = ""
 }
 

--- a/modules/bastion-host/variables.tf
+++ b/modules/bastion-host/variables.tf
@@ -46,3 +46,9 @@ variable "source_image" {
   default     = "gce-uefi-images/ubuntu-1804-lts"
 }
 
+variable "startup_script" {
+  description = "The script to be executed when the host starts. It could be installing a set of tools to interact with clusters or applications."
+  type        = "string"
+  default     = ""
+}
+

--- a/modules/bastion-host/variables.tf
+++ b/modules/bastion-host/variables.tf
@@ -47,7 +47,7 @@ variable "source_image" {
 }
 
 variable "startup_script" {
-  description = "The script to be executed when the host starts. It could be installing a set of tools to interact with clusters or applications."
+  description = "The script to be executed when the bastion host starts. It can be used to install additional software and/or configure the host."
   type        = "string"
   default     = ""
 }


### PR DESCRIPTION
If you need to install tools on the bastion host, such as `kubectl`, the startup script is the place to do it. 

Does this feature make sense?
What would be a good test for this ? 

Thank you for the guidance.
