### PR TITLE
Allow using a static IP for a bastion host

### DIFF
--- a/modules/bastion-host/main.tf
+++ b/modules/bastion-host/main.tf
@@ -24,8 +24,9 @@ resource "google_compute_instance" "bastion_host" {
   network_interface {
     subnetwork = var.subnetwork
 
-    // Provide an empty access_config block to receive an ephemeral IP
+    // If var.static_ip is set use that IP, otherwise this will generate an ephemeral IP
     access_config {
+      nat_ip = var.static_ip
     }
   }
 

--- a/modules/bastion-host/variables.tf
+++ b/modules/bastion-host/variables.tf
@@ -52,3 +52,8 @@ variable "startup_script" {
   default     = ""
 }
 
+variable "static_ip" {
+  description = "A static IP address to attach to the instance. The default will allocate an ephemeral IP"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
This allows setting a static IP for the bastion host (defaulting to null, which allocates an ephemeral IP as it works today).