### PR TITLE
Adding support for white-listing access public sources

### DIFF
--- a/modules/network-firewall/main.tf
+++ b/modules/network-firewall/main.tf
@@ -22,7 +22,7 @@ locals {
 # public - allow ingress from anywhere
 # ---------------------------------------------------------------------------------------------------------------------
 
-resource "google_compute_firewall" "public_allow_all_inbound" {
+resource "google_compute_firewall" "public_allow_inbound" {
   name = "${var.name_prefix}-public-allow-ingress"
 
   project = var.project
@@ -30,7 +30,7 @@ resource "google_compute_firewall" "public_allow_all_inbound" {
 
   target_tags   = [local.public]
   direction     = "INGRESS"
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = var.allowed_public_networks
 
   priority = "1000"
 

--- a/modules/network-firewall/variables.tf
+++ b/modules/network-firewall/variables.tf
@@ -28,3 +28,8 @@ variable "name_prefix" {
   type        = string
 }
 
+variable allowed_public_networks {
+  description = "The public networks that is allowed access to public_subnetwork"
+  default = ["0.0.0.0/0"]
+  type = list(string)
+}

--- a/modules/vpc-network/main.tf
+++ b/modules/vpc-network/main.tf
@@ -115,6 +115,7 @@ module "network_firewall" {
 
   project = var.project
   network = google_compute_network.vpc.self_link
+  allowed_public_networks = var.allowed_public_networks
 
   public_subnetwork  = google_compute_subnetwork.vpc_subnetwork_public.self_link
   private_subnetwork = google_compute_subnetwork.vpc_subnetwork_private.self_link

--- a/modules/vpc-network/variables.tf
+++ b/modules/vpc-network/variables.tf
@@ -65,3 +65,8 @@ variable "enable_flow_logging" {
   default     = true
 }
 
+variable allowed_public_networks {
+  description = "The public networks that is allowed access to public_subnetwork"
+  default = ["0.0.0.0/0"]
+  type = list(string)
+}


### PR DESCRIPTION
Adding possibility to specify which sources that is allowed to access the public network by adding a variable:

```
variable allowed_public_networks {
  description = "The public networks that is allowed access to public_subnetwork"
  default = ["0.0.0.0/0"]
  type = list(string)
}

```

Also renaming firewall rule from `public_allow_all_inbound` to `public_allow_inbound`.