### PR TITLE
Update main.tf - Change NAT to reference private subnet

### DIFF
--- a/modules/vpc-network/main.tf
+++ b/modules/vpc-network/main.tf
@@ -69,7 +69,7 @@ resource "google_compute_router_nat" "vpc_nat" {
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
   subnetwork {
-    name                    = google_compute_subnetwork.vpc_subnetwork_public.self_link
+    name                    = google_compute_subnetwork.vpc_subnetwork_private.self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 }


### PR DESCRIPTION
Changes the NAT to source from the private subnetwork

Is this a mistake? Hesitant to submit this PR as I imagine this works for the people using it, however the comment seems to indicate the public subnet should be excluded rather than included.

Apologies if I am wrong!