### PR TITLE
Fix VPC NAT Routing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
 
       # Fail the build if the pre-commit hooks don't pass. Note: if you run pre-commit install locally, these hooks will
       # execute automatically every time before you commit, ensuring the build never fails at this step!
-      - run: pip install pre-commit==1.11.2
+      - run: pip install pre-commit==1.11.2 cfgv==2.0.1
       - run: pre-commit install
       - run: pre-commit run --all-files
 

--- a/modules/vpc-network/main.tf
+++ b/modules/vpc-network/main.tf
@@ -69,7 +69,7 @@ resource "google_compute_router_nat" "vpc_nat" {
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
   subnetwork {
-    name                    = google_compute_subnetwork.vpc_subnetwork_public.self_link
+    name                    = google_compute_subnetwork.vpc_subnetwork_private.self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 }
@@ -120,4 +120,3 @@ module "network_firewall" {
   public_subnetwork  = google_compute_subnetwork.vpc_subnetwork_public.self_link
   private_subnetwork = google_compute_subnetwork.vpc_subnetwork_private.self_link
 }
-


### PR DESCRIPTION
This PR fixes #52 by ensuring the NAT resource references the private subnetwork instead.