### PR TITLE
Add NAT logging options

### DIFF
--- a/modules/vpc-network/main.tf
+++ b/modules/vpc-network/main.tf
@@ -80,6 +80,15 @@ resource "google_compute_router_nat" "vpc_nat" {
     name                    = google_compute_subnetwork.vpc_subnetwork_private.self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
+
+  dynamic "log_config" {
+    for_each = var.nat_log_config == null ? [] : list(var.nat_log_config)
+
+    content {
+      enable = var.nat_log_config.enable
+      filter = var.nat_log_config.filter
+    }
+  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/vpc-network/variables.tf
+++ b/modules/vpc-network/variables.tf
@@ -74,6 +74,18 @@ variable "log_config" {
   }
 }
 
+variable "nat_log_config" {
+  description = "The logging options for the NAT flow logs. see https://www.terraform.io/docs/providers/google/r/compute_router_nat.html#log_config for more information and examples."
+  type = object({
+    enable = bool
+    filter = string
+  })
+  default = {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}
+
 variable allowed_public_restricted_subnetworks {
   description = "The public networks that is allowed access to the public_restricted subnetwork of the network"
   default     = []


### PR DESCRIPTION
Adds logging options for the VPC NAT.

This change also makes the module idempotent. Without it, the configuration gets updated every time the module is re-applied:

```hcl
# module.commerce_vpc_staging.google_compute_router_nat.vpc_nat will be updated in-place
  ~ resource "google_compute_router_nat" "vpc_nat" {
     [...]      

      - log_config {
          - enable = false -> null
          - filter = "ALL" -> null
        }

     [...]
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```