### PR TITLE
Revert Subnetwork change to resolve #52

### DIFF
--- a/modules/vpc-network/main.tf
+++ b/modules/vpc-network/main.tf
@@ -77,7 +77,7 @@ resource "google_compute_router_nat" "vpc_nat" {
   source_subnetwork_ip_ranges_to_nat = "LIST_OF_SUBNETWORKS"
 
   subnetwork {
-    name                    = google_compute_subnetwork.vpc_subnetwork_private.self_link
+    name                    = google_compute_subnetwork.vpc_subnetwork_public.self_link
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 }


### PR DESCRIPTION
This PR reverts a change made in https://github.com/gruntwork-io/terraform-google-network/pull/53 by replacing it with the originally intended value.