### PR TITLE
Create a second secondary range

### DIFF
--- a/modules/vpc-network/main.tf
+++ b/modules/vpc-network/main.tf
@@ -54,6 +54,15 @@ resource "google_compute_subnetwork" "vpc_subnetwork_public" {
       0
     )
   }
+  
+  secondary_ip_range {
+    range_name = "public-services-2"
+    ip_cidr_range = cidrsubnet(
+      var.second_secondary_cidr_block,
+      var.secondary_cidr_subnetwork_width_delta,
+      0
+    )
+  }
 
   dynamic "log_config" {
     for_each = var.log_config == null ? [] : list(var.log_config)

--- a/modules/vpc-network/variables.tf
+++ b/modules/vpc-network/variables.tf
@@ -47,6 +47,12 @@ variable "secondary_cidr_block" {
   default     = "10.1.0.0/16"
 }
 
+variable "second_secondary_cidr_block" {
+  description = "The IP address range of the VPC's secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27."
+  type        = string
+  default     = "10.1.0.0/16"
+}
+
 variable "secondary_cidr_subnetwork_width_delta" {
   description = "The difference between your network and subnetwork's secondary range netmask; an /16 network and a /20 subnetwork would be 4."
   type        = number

--- a/modules/vpc-network/variables.tf
+++ b/modules/vpc-network/variables.tf
@@ -50,7 +50,7 @@ variable "secondary_cidr_block" {
 variable "second_secondary_cidr_block" {
   description = "The IP address range of the VPC's secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27."
   type        = string
-  default     = "10.1.0.0/16"
+  default     = "10.2.0.0/16"
 }
 
 variable "secondary_cidr_subnetwork_width_delta" {


### PR DESCRIPTION
This PR:

- Create a second secondary range for vpc_network module on public subnetwork 

To prevent this error: `Error: googleapi: Error 400: Pod secondary range name (public-services) should not be the same as service secondary range name., badRequest` when we use with gke_cluster module from gruntwork-io. 