### PR TITLE
fix: pod secondary range name should not be same as service secondary range name

### DIFF
--- a/modules/vpc-network/main.tf
+++ b/modules/vpc-network/main.tf
@@ -47,11 +47,20 @@ resource "google_compute_subnetwork" "vpc_subnetwork_public" {
   ip_cidr_range            = cidrsubnet(var.cidr_block, var.cidr_subnetwork_width_delta, 0)
 
   secondary_ip_range {
-    range_name = "public-services"
+    range_name = "public-cluster"
     ip_cidr_range = cidrsubnet(
       var.secondary_cidr_block,
       var.secondary_cidr_subnetwork_width_delta,
       0
+    )
+  }
+
+  secondary_ip_range {
+    range_name = "public-services"
+    ip_cidr_range = cidrsubnet(
+      var.secondary_cidr_block,
+      var.secondary_cidr_subnetwork_width_delta,
+      1 * (2 + var.secondary_cidr_subnetwork_spacing)
     )
   }
 

--- a/modules/vpc-network/outputs.tf
+++ b/modules/vpc-network/outputs.tf
@@ -33,6 +33,14 @@ output "public_subnetwork_secondary_range_name" {
   value = google_compute_subnetwork.vpc_subnetwork_public.secondary_ip_range[0].range_name
 }
 
+output "public_services_secondary_cidr_block" {
+  value = google_compute_subnetwork.vpc_subnetwork_public.secondary_ip_range[1].ip_cidr_range
+}
+
+output "public_services_secondary_range_name" {
+  value = google_compute_subnetwork.vpc_subnetwork_public.secondary_ip_range[1].range_name
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # Private Subnetwork Outputs
 # ---------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
* attempt to fix gruntwork-io/terraform-google-gke/issues/118
* create another secondary_ip_range block with different name and setting newbits to 2
* outputs to get the new ip range cidr block and name

this fix is in tandem with https://github.com/gruntwork-io/terraform-google-gke/pull/120