### PR TITLE
Fix: pod secondary range name should not be same as service secondary range name

### DIFF
--- a/modules/vpc-network/main.tf
+++ b/modules/vpc-network/main.tf
@@ -47,11 +47,20 @@ resource "google_compute_subnetwork" "vpc_subnetwork_public" {
   ip_cidr_range            = cidrsubnet(var.cidr_block, var.cidr_subnetwork_width_delta, 0)
 
   secondary_ip_range {
-    range_name = "public-services"
+    range_name = "public-cluster"
     ip_cidr_range = cidrsubnet(
       var.secondary_cidr_block,
       var.secondary_cidr_subnetwork_width_delta,
       0
+    )
+  }
+
+  secondary_ip_range {
+    range_name = "public-services"
+    ip_cidr_range = cidrsubnet(
+      var.secondary_cidr_block,
+      var.secondary_cidr_subnetwork_width_delta,
+      1 * (2 + var.secondary_cidr_subnetwork_spacing)
     )
   }
 

--- a/modules/vpc-network/main.tf
+++ b/modules/vpc-network/main.tf
@@ -47,7 +47,7 @@ resource "google_compute_subnetwork" "vpc_subnetwork_public" {
   ip_cidr_range            = cidrsubnet(var.cidr_block, var.cidr_subnetwork_width_delta, 0)
 
   secondary_ip_range {
-    range_name = "public-cluster"
+    range_name = var.public_subnetwork_secondary_range_name
     ip_cidr_range = cidrsubnet(
       var.secondary_cidr_block,
       var.secondary_cidr_subnetwork_width_delta,
@@ -56,7 +56,7 @@ resource "google_compute_subnetwork" "vpc_subnetwork_public" {
   }
 
   secondary_ip_range {
-    range_name = "public-services"
+    range_name = var.public_services_secondary_range_name
     ip_cidr_range = cidrsubnet(
       var.secondary_cidr_block,
       var.secondary_cidr_subnetwork_width_delta,

--- a/modules/vpc-network/outputs.tf
+++ b/modules/vpc-network/outputs.tf
@@ -33,6 +33,14 @@ output "public_subnetwork_secondary_range_name" {
   value = google_compute_subnetwork.vpc_subnetwork_public.secondary_ip_range[0].range_name
 }
 
+output "public_services_secondary_cidr_block" {
+  value = google_compute_subnetwork.vpc_subnetwork_public.secondary_ip_range[1].ip_cidr_range
+}
+
+output "public_services_secondary_range_name" {
+  value = google_compute_subnetwork.vpc_subnetwork_public.secondary_ip_range[1].range_name
+}
+
 # ---------------------------------------------------------------------------------------------------------------------
 # Private Subnetwork Outputs
 # ---------------------------------------------------------------------------------------------------------------------

--- a/modules/vpc-network/variables.tf
+++ b/modules/vpc-network/variables.tf
@@ -41,6 +41,18 @@ variable "cidr_subnetwork_spacing" {
   default     = 0
 }
 
+variable "public_subnetwork_secondary_range_name" {
+  description = "The name associated with the pod subnetwork secondary range, used when adding an alias IP range to a VM instance. The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the subnetwork."
+  type        = string
+  default     = "public-cluster"
+}
+
+variable "public_services_secondary_range_name" {
+  description = "The name associated with the services subnetwork secondary range, used when adding an alias IP range to a VM instance. The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the subnetwork."
+  type        = string
+  default     = "public-services"
+}
+
 variable "secondary_cidr_block" {
   description = "The IP address range of the VPC's secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27."
   type        = string


### PR DESCRIPTION
This PR fixes a GKE cluster creation issue (see https://github.com/gruntwork-io/terraform-google-gke/issues/118) due to a change in Google's APIs that prevents the pod secondary range name having the same name as the services secondary range name. We set defaults for the new secondary range names, however we use variables to allow backwards compatibility with existing GKE clusters.

It also:
* creates another secondary_ip_range block with a different name, setting newbits to 2
* outputs to get the new ip range cidr block and name

Thanks to @brianpham for the original PR.