### PR TITLE
Migrate bastion host image to the new project

### DIFF
--- a/modules/bastion-host/variables.tf
+++ b/modules/bastion-host/variables.tf
@@ -43,7 +43,7 @@ variable "machine_type" {
 variable "source_image" {
   description = "The source image to build the VM using. Specified by path reference or by {{project}}/{{image-family}}"
   type        = string
-  default     = "gce-uefi-images/ubuntu-1804-lts"
+  default     = "ubuntu-os-cloud/ubuntu-1804-lts"
 }
 
 variable "startup_script" {


### PR DESCRIPTION
This PR changes the image project `gce-uefi-images` to the default prod image project. The `gce-uefi-images` project is being deprecated, so we should just use the default image project. People used to use images in `gce-uefi-images` to use Shielded VM features, but now Shielded VM is by default so the gce-uefi-images project is not necessary anymore. For more info see: https://github.com/hashicorp/terraform-provider-google/pull/8572 and the issue: https://github.com/hashicorp/terraform-provider-google/issues/8512