### PR TITLE
Allow the public and private services secondary IP CIDR ranges to be specified manually

### DIFF
--- a/modules/network-firewall/main.tf
+++ b/modules/network-firewall/main.tf
@@ -83,6 +83,7 @@ resource "google_compute_firewall" "private_allow_all_network_inbound" {
   source_ranges = [
     data.google_compute_subnetwork.public_subnetwork.ip_cidr_range,
     data.google_compute_subnetwork.public_subnetwork.secondary_ip_range[0].ip_cidr_range,
+    data.google_compute_subnetwork.public_subnetwork.secondary_ip_range[1].ip_cidr_range,
     data.google_compute_subnetwork.private_subnetwork.ip_cidr_range,
     data.google_compute_subnetwork.private_subnetwork.secondary_ip_range[0].ip_cidr_range,
   ]

--- a/modules/vpc-network/main.tf
+++ b/modules/vpc-network/main.tf
@@ -57,7 +57,7 @@ resource "google_compute_subnetwork" "vpc_subnetwork_public" {
 
   secondary_ip_range {
     range_name = var.public_services_secondary_range_name
-    ip_cidr_range = cidrsubnet(
+    ip_cidr_range = var.public_services_secondary_cidr_block != null ? var.public_services_secondary_cidr_block : cidrsubnet(
       var.secondary_cidr_block,
       var.secondary_cidr_subnetwork_width_delta,
       1 * (2 + var.secondary_cidr_subnetwork_spacing)
@@ -113,7 +113,7 @@ resource "google_compute_subnetwork" "vpc_subnetwork_private" {
 
   secondary_ip_range {
     range_name = "private-services"
-    ip_cidr_range = cidrsubnet(
+    ip_cidr_range = var.private_services_secondary_cidr_block != null ? var.private_services_secondary_cidr_block : cidrsubnet(
       var.secondary_cidr_block,
       var.secondary_cidr_subnetwork_width_delta,
       1 * (1 + var.secondary_cidr_subnetwork_spacing)

--- a/modules/vpc-network/variables.tf
+++ b/modules/vpc-network/variables.tf
@@ -59,6 +59,18 @@ variable "secondary_cidr_block" {
   default     = "10.1.0.0/16"
 }
 
+variable "public_services_secondary_cidr_block" {
+  description = "The IP address range of the VPC's public services secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27. Note: this variable is optional and is used primarily for backwards compatibility, if not specified a range will be calculated using var.secondary_cidr_block, var.secondary_cidr_subnetwork_width_delta and var.secondary_cidr_subnetwork_spacing."
+  type        = string
+  default     = null
+}
+
+variable "private_services_secondary_cidr_block" {
+  description = "The IP address range of the VPC's private services secondary address range in CIDR notation. A prefix of /16 is recommended. Do not use a prefix higher than /27. Note: this variable is optional and is used primarily for backwards compatibility, if not specified a range will be calculated using var.secondary_cidr_block, var.secondary_cidr_subnetwork_width_delta and var.secondary_cidr_subnetwork_spacing."
+  type        = string
+  default     = null
+}
+
 variable "secondary_cidr_subnetwork_width_delta" {
   description = "The difference between your network and subnetwork's secondary range netmask; an /16 network and a /20 subnetwork would be 4."
   type        = number


### PR DESCRIPTION
This PR adds two new variables: `var.public_services_secondary_cidr_block` and `var.private_services_secondary_cidr_block` that allow the public and private services secondary IP CIDR ranges to be specified manually. It is intended for backwards compatibility with existing GKE clusters to prevent changing the automatically assigned networking and recreating the clusters.