### PR TITLE
[IAC-1677] Replace gofmt with goimports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,8 @@ jobs:
       - run:
           command: |
             pip install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0 yapf
+            go get golang.org/x/tools/cmd/goimports
+            export GOPATH=~/go/bin && export PATH=$PATH:$GOPATH 
             pre-commit install
             pre-commit run --all-files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: v0.1.10
     hooks:
       - id: terraform-fmt
-      - id: gofmt
+      - id: goimports
 

--- a/test/bastion_host_test.go
+++ b/test/bastion_host_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-        test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 func TestBastionHost(t *testing.T) {

--- a/test/bastion_host_test.go
+++ b/test/bastion_host_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 func TestBastionHost(t *testing.T) {

--- a/test/bastion_host_test.go
+++ b/test/bastion_host_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+        test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 func TestBastionHost(t *testing.T) {

--- a/test/management_network_test.go
+++ b/test/management_network_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 func TestNetworkManagement(t *testing.T) {

--- a/test/management_network_test.go
+++ b/test/management_network_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/retry"
 	"github.com/gruntwork-io/terratest/modules/ssh"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 func TestNetworkManagement(t *testing.T) {


### PR DESCRIPTION
Replace gofmt with goimports in the pre-commit configuration. Note: This PR was opened using git-xargs.