### PR TITLE
Update f1-micro to e2-micro instance

### DIFF
--- a/modules/bastion-host/variables.tf
+++ b/modules/bastion-host/variables.tf
@@ -37,7 +37,7 @@ variable "tag" {
 variable "machine_type" {
   description = "The machine type of the instance."
   type        = string
-  default     = "f1-micro"
+  default     = "e2-micro"
 }
 
 variable "source_image" {


### PR DESCRIPTION
I just got an email from GCP stating that the f1-micro is being retired from free tier access and needs to be updated to e2-micro. This PR makes that change.